### PR TITLE
ci: sync release workflow and README license badge to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release Obsidian plugin
+
+on:
+    push:
+        tags:
+            - "*"
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+
+            - name: Build plugin
+              run: |
+                  npm ci
+                  npm run build
+
+            - name: Verify tag matches manifest version
+              run: |
+                  tag="${GITHUB_REF#refs/tags/}"
+                  version="$(node -p "require('./manifest.json').version")"
+                  if [ "$tag" != "$version" ]; then
+                      echo "::error::Tag '$tag' must match manifest.json version '$version' (Obsidian requirement)."
+                      exit 1
+                  fi
+
+            - name: Verify release artifacts
+              run: |
+                  set -e
+                  for file in main.js manifest.json styles.css transformers.min.js ort-wasm-simd.wasm ort-wasm.wasm; do
+                      if [ ! -f "$file" ]; then
+                          echo "::error::Missing release artifact: $file"
+                          exit 1
+                      fi
+                  done
+                  shopt -s nullglob
+                  workers=(pdf.worker-*.min.mjs)
+                  if [ ${#workers[@]} -eq 0 ]; then
+                      echo "::error::Missing release artifact: pdf.worker-*.min.mjs"
+                      exit 1
+                  fi
+                  echo "Release artifacts:"
+                  ls -lh main.js manifest.json styles.css transformers.min.js ort-wasm-simd.wasm ort-wasm.wasm "${workers[@]}"
+
+            - name: Create GitHub release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  tag="${GITHUB_REF#refs/tags/}"
+                  gh release create "$tag" \
+                      --title "$tag" \
+                      --generate-notes \
+                      main.js \
+                      manifest.json \
+                      styles.css \
+                      transformers.min.js \
+                      ort-wasm-simd.wasm \
+                      ort-wasm.wasm \
+                      pdf.worker-*.min.mjs

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lecture Lens
 
 ![GitHub release](https://img.shields.io/github/v/release/Yima-Gu/obsidian-lecture-lens)
-![License](https://img.shields.io/github/license/Yima-Gu/obsidian-lecture-lens)
+![License](https://img.shields.io/badge/License-MIT-blue.svg)
 
 > Turn lecture slides and whiteboard photos into structured Obsidian notes — powered by multimodal LLMs.
 >
@@ -31,12 +31,12 @@
 
 ### Supported providers (presets)
 
-| Provider | Base URL | Default model |
-|----------|----------|---------------|
-| OpenAI | `https://api.openai.com/v1` | `gpt-4o` |
-| DeepSeek | `https://api.deepseek.com` | `deepseek-v4-flash` |
-| Kimi | `https://api.moonshot.cn/v1` | `moonshot-v1-8k-vision-preview` |
-| Gemini | Google OpenAI-compatible endpoint | `gemini-2.0-flash` |
+| Provider | Base URL                          | Default model                   |
+| -------- | --------------------------------- | ------------------------------- |
+| OpenAI   | `https://api.openai.com/v1`       | `gpt-4o`                        |
+| DeepSeek | `https://api.deepseek.com`        | `deepseek-v4-flash`             |
+| Kimi     | `https://api.moonshot.cn/v1`      | `moonshot-v1-8k-vision-preview` |
+| Gemini   | Google OpenAI-compatible endpoint | `gemini-2.0-flash`              |
 
 > **Vision chat**: use a VLM such as `gpt-4o`, Kimi `*-vision-*`, or `deepseek-vl2`. Text models like `deepseek-v4-flash` do not accept images.
 
@@ -50,13 +50,13 @@
 **Manual / local development**
 
 1. Clone into your vault:
-   ```bash
-   cd /path/to/vault/.obsidian/plugins
-   git clone git@github.com:Yima-Gu/obsidian-lecture-lens.git lecture-lens
-   cd lecture-lens
-   npm install
-   npm run build
-   ```
+    ```bash
+    cd /path/to/vault/.obsidian/plugins
+    git clone git@github.com:Yima-Gu/obsidian-lecture-lens.git lecture-lens
+    cd lecture-lens
+    npm install
+    npm run build
+    ```
 2. Enable the plugin in **Settings → Community plugins**
 3. Reload Obsidian (`Cmd+R`)
 
@@ -73,8 +73,8 @@
 - **Local-first** — notes stay in your vault; RAG index is stored under `.obsidian/plugins/lecture-lens/`
 - **Explicit file context** — chat only reads vault notes you attach via `@` or the current-note chip (never arbitrary disk paths)
 - **API key storage**
-  - **Desktop**: encrypted with OS keychain via Electron `safeStorage` when available
-  - **Mobile / fallback**: stored in plugin data (same risk as other local secrets — protect vault access)
+    - **Desktop**: encrypted with OS keychain via Electron `safeStorage` when available
+    - **Mobile / fallback**: stored in plugin data (same risk as other local secrets — protect vault access)
 - **Network** — API calls go only to the LLM endpoint you configure; no hidden telemetry
 
 ### Development


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow (build + upload 7 Obsidian plugin assets on tag push)
- Fix README license badge to explicit MIT

## Test plan
- [ ] Merge PR
- [ ] Push a version tag on master to verify release workflow runs

Made with [Cursor](https://cursor.com)