### PR TITLE
fix: release workflow pdf worker filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,9 @@ jobs:
                       fi
                   done
                   shopt -s nullglob
-                  workers=(pdf.worker-*.min.mjs)
+                  workers=(pdf.worker*.min.mjs)
                   if [ ${#workers[@]} -eq 0 ]; then
-                      echo "::error::Missing release artifact: pdf.worker-*.min.mjs"
+                      echo "::error::Missing release artifact: pdf.worker*.min.mjs"
                       exit 1
                   fi
                   echo "Release artifacts:"
@@ -66,4 +66,4 @@ jobs:
                       transformers.min.js \
                       ort-wasm-simd.wasm \
                       ort-wasm.wasm \
-                      pdf.worker-*.min.mjs
+                      pdf.worker*.min.mjs


### PR DESCRIPTION
## Summary
Release workflow failed because it looked for `pdf.worker-*.min.mjs` while master build outputs `pdf.worker.min.mjs`.

## Test plan
- [ ] Merge PR
- [ ] Re-push tag `1.1.0` to create GitHub Release

Made with [Cursor](https://cursor.com)